### PR TITLE
Simplify ifs

### DIFF
--- a/src/components/DataKeyPair.tsx
+++ b/src/components/DataKeyPair.tsx
@@ -37,14 +37,15 @@ export const DataKeyPair: React.FC<DataKeyPairProps> = (props) => {
   const editable = useMemo(() => {
     if (storeEditable === false) {
       return false
-    } else if (!propsEditable) {
+    }
+    if (!propsEditable) {
       // props.editable is false which means we cannot provide the suitable way to edit it
       return false
-    } else if (typeof storeEditable === 'function') {
-      return !!storeEditable(path, value)
-    } else {
-      return propsEditable
     }
+    if (typeof storeEditable === 'function') {
+      return !!storeEditable(path, value)
+    }
+    return propsEditable
   }, [path, propsEditable, storeEditable, value])
   const [tempValue, setTempValue] = useState(value)
   const depth = path.length

--- a/src/components/DataTypes/Object.tsx
+++ b/src/components/DataTypes/Object.tsx
@@ -191,13 +191,10 @@ export const ObjectType: React.FC<DataItemProps<object>> = (props) => {
       // object
       let entries: [key: string, value: unknown][] = Object.entries(value)
       if (objectSortKeys) {
-        entries = entries.sort(([a], [b]) => {
-          if (objectSortKeys === true) {
-            return a.localeCompare(b)
-          } else {
-            return objectSortKeys(a, b)
-          }
-        })
+        entries = entries.sort(([a], [b]) => objectSortKeys === true
+            ? a.localeCompare(b)
+            : objectSortKeys(a, b)
+        )
       }
       const elements = entries.slice(0, displayLength).map(([key, value]) => {
         const path = [...props.path, key]

--- a/src/stores/typeRegistry.tsx
+++ b/src/stores/typeRegistry.tsx
@@ -70,14 +70,13 @@ export function matchTypeComponents<Value> (
       }
     }
   }
-  if (potential === undefined && typeof value === 'object') {
-    return objectType as unknown as DataType<Value>
-  } else {
-    if (potential === undefined) {
-      throw new DevelopmentError('this is not possible')
+  if (potential === undefined) {
+    if (typeof value === 'object') {
+      return objectType as unknown as DataType<Value>
     }
-    return potential
+    throw new DevelopmentError('this is not possible')
   }
+  return potential
 }
 
 export function useTypeComponents (value: unknown) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -105,13 +105,13 @@ export const isCycleReference = (
   while (currentRoot !== value || arr.length !== 0) {
     if (typeof currentRoot !== 'object' || currentRoot === null) {
       return false
-    } else if (Object.is(currentRoot, value)) {
+    }
+    if (Object.is(currentRoot, value)) {
       return currentPath.reduce<string>((path, value, currentIndex) => {
         if (typeof value === 'number') {
           return path + `[${value}]`
-        } else {
-          return path + `${currentIndex === 0 ? '' : '.'}${value}`
         }
+        return path + `${currentIndex === 0 ? '' : '.'}${value}`
       }, '')
     }
     const target = arr.shift()!


### PR DESCRIPTION
There is no need to use `else` if in previous `if` was `return` instruction. It enhances reading at least.