### PR TITLE
Show three dots only on collapsed strings

### DIFF
--- a/src/stores/typeRegistry.tsx
+++ b/src/stores/typeRegistry.tsx
@@ -225,7 +225,7 @@ export function predefined (): DataType<any>[] {
             >
               &quot;
               {value}
-              {hasRest && <span>...</span>}
+              {showRest ? <span>...</span> : <></>}
               &quot;
             </Box>
           )


### PR DESCRIPTION
When a string is collapsed, it always shows the three dots (...) at the end in both states, collapsed and uncollapsed.

This PR should fix this behaviour.

(Unfortunately I'm unable to test this locally. I'm unable get this project up and running. I can build the sources with 'yarn && yarn build', but when I add it to another project (even a fresh create-react-app) I got errors 'Invalid hook call. Hooks can only be called inside of the body of a function component.' and 'Uncaught TypeError: Cannot read properties of null (reading 'useMemo')'. I'm sorry, my skills end here.)