### PR TITLE
fix: cannot resolve `@textea/dev-kit/utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.1",
+    "@textea/dev-kit": "^1.1.0",
     "copy-to-clipboard": "^3.3.3",
     "group-items": "^2.2.0",
     "zustand": "^4.1.5"
@@ -84,7 +85,6 @@
     "@rollup/plugin-replace": "^5.0.2",
     "@swc/core": "^1.3.24",
     "@testing-library/react": "^13.4.0",
-    "@textea/dev-kit": "^1.1.0",
     "@types/node": "^18.11.17",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",


### PR DESCRIPTION
This fixes https://github.com/TexteaInc/json-viewer/issues/133.

I think that it's because the dev-kit lib got put as a dev dependency, so when you npm install, it doesn't come along.

I think it's just an oopsie. Moving it from devDependencies to dependencies in package.json will fix this.

I think that a better fix will be to not even have this "DevelopmentError" in the code as it seems rather odd, but this at least fixes the issue.