### PR TITLE
fix(ui): remove left margin in key-value separator

### DIFF
--- a/src/components/DataKeyPair.tsx
+++ b/src/components/DataKeyPair.tsx
@@ -246,10 +246,10 @@ export const DataKeyPair: React.FC<DataKeyPairProps> = (props) => {
           (
             isRoot
               ? (rootName !== false
-                  ? <DataBox sx={{ mx: 0.5 }}>:</DataBox>
+                  ? <DataBox sx={{ mr: 0.5 }}>:</DataBox>
                   : null)
               : nestedIndex === undefined && (
-               <DataBox sx={{ mx: 0.5 }}>:</DataBox>
+               <DataBox sx={{ mr: 0.5 }}>:</DataBox>
               )
           )
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40242971/212189316-58a03b1b-65c3-4ad2-96ff-0e77d77b4a2a.png)

After:
![image](https://user-images.githubusercontent.com/40242971/212189408-242b3a24-ff37-4456-a7f1-4700a44a5ba1.png)