### PR TITLE
Don't pull unused @mui modules by using path imports

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -28,6 +28,7 @@ const external = [
   '@emotion/react/jsx-dev-runtime',
   '@mui/material',
   '@mui/material/styles',
+  /@mui\/material\/.*/,
   'copy-to-clipboard',
   'zustand',
   'zustand/context',
@@ -47,7 +48,9 @@ const outputMatrix = (
     format,
     banner: `/// <reference types="./${baseName}.d.ts" />`,
     globals: external.reduce((object, module) => {
-      object[module] = module
+      if (typeof module === 'string') {
+        object[module] = module
+      }
       return object
     }, {} as Record<string, string>)
   }))
@@ -124,7 +127,7 @@ const dtsMatrix = (): RollupOptions[] => {
 
 const build: RollupOptions[] = [
   buildMatrix('./src/index.tsx', 'index', {
-    format: ['es', 'umd'],
+    format: ['es', 'cjs'],
     browser: false,
     dts: true
   }),

--- a/src/components/DataKeyPair.tsx
+++ b/src/components/DataKeyPair.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material'
+import Box from '@mui/material/Box'
 import type { ComponentProps } from 'react'
 import React, { useCallback, useMemo, useState } from 'react'
 

--- a/src/components/DataTypes/Function.tsx
+++ b/src/components/DataTypes/Function.tsx
@@ -2,7 +2,8 @@
  * Use NoSsr on function value.
  *  Because in Next.js SSR, the function will be translated to other type
  */
-import { Box, NoSsr } from '@mui/material'
+import Box from '@mui/material/Box'
+import NoSsr from '@mui/material/NoSsr'
 import React from 'react'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'

--- a/src/components/DataTypes/Object.tsx
+++ b/src/components/DataTypes/Object.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material'
+import Box from '@mui/material/Box'
 import React, { useMemo, useState } from 'react'
 
 import { useTextColor } from '../../hooks/useColor'

--- a/src/components/DataTypes/createEasyType.tsx
+++ b/src/components/DataTypes/createEasyType.tsx
@@ -1,4 +1,4 @@
-import { InputBase } from '@mui/material'
+import InputBase from '@mui/material/InputBase'
 import React, { useCallback } from 'react'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,5 +1,5 @@
 import type { SvgIconProps } from '@mui/material'
-import { SvgIcon } from '@mui/material'
+import SvgIcon from '@mui/material/SvgIcon'
 import React from 'react'
 
 const BaseIcon: React.FC<SvgIconProps> = ({ d, ...props }) => {

--- a/src/components/mui/DataBox.tsx
+++ b/src/components/mui/DataBox.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material'
+import Box from '@mui/material/Box'
 import type { ComponentProps } from 'react'
 import React from 'react'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import Paper from '@mui/material/Paper'
-import createTheme from '@mui/material/styles/createTheme'
-import ThemeProvider from '@mui/material/styles/ThemeProvider'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { DataKeyPair } from './components/DataKeyPair'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import Paper from '@mui/material/Paper'
-import { createTheme, ThemeProvider } from '@mui/material/styles'
+import createTheme from '@mui/material/styles/createTheme'
+import ThemeProvider from '@mui/material/styles/ThemeProvider'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { DataKeyPair } from './components/DataKeyPair'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
-import {
-  createTheme, Paper,
-  ThemeProvider
-} from '@mui/material'
+import Paper from '@mui/material/Paper'
+import createTheme from '@mui/material/styles/createTheme'
+import ThemeProvider from '@mui/material/styles/ThemeProvider'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { DataKeyPair } from './components/DataKeyPair'

--- a/src/stores/typeRegistry.tsx
+++ b/src/stores/typeRegistry.tsx
@@ -1,6 +1,6 @@
-import { Box } from '@mui/material'
+import Box from '@mui/material/Box'
 import type { SetStateAction } from 'react'
-import React, { memo, useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import create from 'zustand'
 import createStore from 'zustand/context'
 import { combine } from 'zustand/middleware'


### PR DESCRIPTION
## Problem

Webpack only tree shakes during minification, so this package is pulling in everything from @mui when developing. This results in a very large amount of modules and causes a significant slowdown for development.

[This is a known problem](https://github.com/mui/material-ui/issues/10857), and upon browsing the material-ui github, [I could see they are importing the same way.](https://github.com/mui/material-ui/search?q=themeprovider)

Attempting to fix this downstream by applying production settings in development doesn't seem to work, it just hangs.
On top of that, the attempted fix https://github.com/TexteaInc/json-viewer/pull/169 doesn't reduce the bundle size either. It transforms the import statements but ends up pulling in other imports from those imports. This solution inlines the @mui dependencies so that the package is minimized in development.

### Resources
- [What is different between webpack production and development regarding tree shaking](https://stackoverflow.com/questions/56350947/what-is-different-between-webpack-production-and-development-regarding-tree-shak)
- [Webpack Optimization Defaults](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/config/defaults.js#L1129-L1209)
- [webpack/examples/cjs-tree-shaking/webpack.config.js](https://github.com/webpack/webpack/blob/c181294865dca01b28e6e316636fef5f2aad4eb6/examples/cjs-tree-shaking/webpack.config.js)

## Solution

Use path imports to only pull in necessary dependencies from @mui.

Tested with a next.js boilerplate using version 13.1.2.

Ran `npm link` inside `@textea/json-viewer`
Ran `npm link @textea/json-viewer` inside the dependent project

Compile time output:
> event - compiled client and server successfully in 9.3s (1173 modules)

Next.js module trace output:
![image](https://user-images.githubusercontent.com/17555572/212502572-095ad900-45b8-452a-9503-e22dfd8e188e.png)

[Previous size:](https://github.com/TexteaInc/json-viewer/pull/147#issuecomment-1382674042)

> event - compiled client and server successfully in 17.2s (1936 modules)

## Explored Alternatives

https://github.com/TexteaInc/json-viewer/pull/169