### PR TITLE
fix: reduce MUI size by using `@swc/plugin-transform-imports`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,8 +94,7 @@ module.exports = {
             importNames: ['styled', 'createTheme', 'ThemeProvider'],
             message: `
 Use "import { styled } from '@mui/material/styles'" instead.
-Use "import { createTheme } from '@mui/material/styles'" instead.
-Use "import { ThemeProvider } from '@mui/system'" instead.`
+Use "import { createTheme, ThemeProvider } from '@mui/material/styles'" instead.`
           }
         ],
         patterns: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,16 @@ module.exports = {
     '@typescript-eslint/no-restricted-imports': [
       'error',
       {
+        paths: [
+          {
+            name: '@mui/material',
+            importNames: ['styled', 'createTheme', 'ThemeProvider'],
+            message: `
+Use "import { styled } from '@mui/material/styles'" instead.
+Use "import { createTheme } from '@mui/material/styles'" instead.
+Use "import { ThemeProvider } from '@mui/system'" instead.`
+          }
+        ],
         patterns: [
           {
             group: ['**/dist'],

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tsconfig.tsbuildinfo
 .eslintcache
 node_modules
 
+.swc
 .next
 .vercel
 coverage

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.2",
     "@swc/core": "^1.3.27",
+    "@swc/plugin-transform-imports": "^1.5.36",
     "@testing-library/react": "^13.4.0",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -50,8 +50,8 @@ const replacePlugin = replace({
 const esmTransformImportsPlugin: [string, Record<string, any>] = [
   '@swc/plugin-transform-imports',
   {
-    '@mui/material': { transform: '@mui/material/{{member}}' },
-    '@mui/material/styles': { transform: '@mui/material/styles/{{member}}' }
+    '@mui/material': { transform: '@mui/material/{{member}}/index.js' },
+    '@mui/material/styles': { transform: '@mui/material/styles/{{member}}.js' }
   }
 ]
 

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -27,7 +27,7 @@ const external = [
   '@emotion/react/jsx-runtime',
   '@emotion/react/jsx-dev-runtime',
   '@mui/material',
-  '@mui/material/styles',
+  /@mui\/material\/.*/,
   'copy-to-clipboard',
   'zustand',
   'zustand/context',
@@ -47,7 +47,9 @@ const outputMatrix = (
     format,
     banner: `/// <reference types="./${baseName}.d.ts" />`,
     globals: external.reduce((object, module) => {
-      object[module] = module
+      if (typeof module === 'string') {
+        object[module] = module
+      }
       return object
     }, {} as Record<string, string>)
   }))
@@ -101,6 +103,20 @@ const buildMatrix = (input: string, output: string, config: {
               runtime: 'automatic',
               importSource: '@emotion/react'
             }
+          },
+          experimental: {
+            plugins: config.browser
+              ? []
+              : [
+                  [
+                    '@swc/plugin-transform-imports',
+                    {
+                      '@mui/material': {
+                        transform: '@mui/material/{{member}}'
+                      }
+                    }
+                  ]
+                ]
           }
         }
       }))
@@ -124,7 +140,7 @@ const dtsMatrix = (): RollupOptions[] => {
 
 const build: RollupOptions[] = [
   buildMatrix('./src/index.tsx', 'index', {
-    format: ['es', 'umd'],
+    format: ['es', 'cjs'],
     browser: false,
     dts: true
   }),

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -8,20 +8,15 @@ import replace from '@rollup/plugin-replace'
 import type {
   ModuleFormat,
   OutputOptions,
-  RollupCache,
   RollupOptions
 } from 'rollup'
 import dts from 'rollup-plugin-dts'
 import { defineRollupSwcOption, swc } from 'rollup-plugin-swc3'
 import { fileURLToPath } from 'url'
 
-let cache: RollupCache
-
-const dtsOutput = new Set<[string, string]>()
-
 const outputDir = fileURLToPath(new URL('dist', import.meta.url))
 
-const external = [
+const externalDeps = [
   '@emotion/react',
   '@emotion/styled',
   '@emotion/react/jsx-runtime',
@@ -37,16 +32,47 @@ const external = [
   'react-dom',
   'react-dom/client'
 ]
+
+const aliasPlugin = alias({
+  entries: [
+    { find: 'react', replacement: '@emotion/react' },
+    { find: 'react/jsx-runtime', replacement: '@emotion/react/jsx-runtime' },
+    { find: 'react/jsx-dev-runtime', replacement: '@emotion/react/jsx-dev-runtime' }
+  ]
+})
+
+const replacePlugin = replace({
+  preventAssignment: true,
+  'process.env.NODE_ENV': JSON.stringify('production'),
+  'typeof window': JSON.stringify('object')
+})
+
+const esmTransformImportsPlugin: [string, Record<string, any>] = [
+  '@swc/plugin-transform-imports',
+  {
+    '@mui/material': { transform: '@mui/material/{{member}}' },
+    '@mui/material/styles': { transform: '@mui/material/styles/{{member}}' }
+  }
+]
+
+const cjsTransformImportsPlugin: [string, Record<string, any>] = [
+  '@swc/plugin-transform-imports',
+  {
+    '@mui/material': { transform: '@mui/material/node/{{member}}' },
+    '@mui/material/styles': { transform: '@mui/material/node/styles/{{member}}' }
+  }
+]
+
 const outputMatrix = (
   name: string, format: ModuleFormat[]): OutputOptions[] => {
   const baseName = basename(name)
-  return format.flatMap(format => ({
+  return format.map(format => ({
     file: resolve(outputDir, `${baseName}.${format === 'es' ? 'm' : ''}js`),
     sourcemap: false,
     name: 'JsonViewer',
     format,
     banner: `/// <reference types="./${baseName}.d.ts" />`,
-    globals: external.reduce((object, module) => {
+    globals: externalDeps.reduce((object, module) => {
       if (typeof module === 'string') {
         object[module] = module
       }
@@ -58,101 +84,64 @@ const outputMatrix = (
 const buildMatrix = (input: string, output: string, config: {
   format: ModuleFormat[]
   browser: boolean
-  dts: boolean
-}): RollupOptions => {
-  if (config.dts) {
-    dtsOutput.add([input, output])
-  }
-  return {
-    input,
-    output: outputMatrix(output, config.format),
-    cache,
-    external: config.browser ? [] : external,
-    plugins: [
-      alias({
-        entries: config.browser
-          ? []
-          : [
-              { find: 'react', replacement: '@emotion/react' },
-              {
-                find: 'react/jsx-dev-runtime',
-                replacement: '@emotion/react/jsx-dev-runtime'
-              },
-              {
-                find: 'react/jsx-runtime',
-                replacement: '@emotion/react/jsx-runtime'
-              }
-            ]
-      }),
-      config.browser && replace({
-        preventAssignment: true,
-        'process.env.NODE_ENV': JSON.stringify('production'),
-        'typeof window': JSON.stringify('object')
-      }),
-      commonjs(),
-      nodeResolve(),
-      swc(defineRollupSwcOption({
-        jsc: {
-          externalHelpers: true,
-          parser: {
-            syntax: 'typescript',
-            tsx: true
-          },
-          transform: {
-            react: {
-              runtime: 'automatic',
-              importSource: '@emotion/react'
-            }
-          },
-          experimental: {
-            plugins: config.browser
-              ? []
-              : [
-                  [
-                    '@swc/plugin-transform-imports',
-                    {
-                      '@mui/material': {
-                        transform: '@mui/material/{{member}}'
-                      },
-                      '@mui/material/styles': {
-                        transform: '@mui/material/styles/{{member}}'
-                      }
-                    }
-                  ]
-                ]
-          }
-        }
-      }))
-    ]
-  }
-}
+}): RollupOptions[] => {
+  return [
+    ...config.format.map(format => ({
+      input,
+      output: outputMatrix(output, [format]),
+      external: config.browser ? [] : externalDeps,
 
-const dtsMatrix = (): RollupOptions[] => {
-  return [...dtsOutput.values()].flatMap(([input, output]) => ({
-    input,
-    cache,
-    output: {
-      file: resolve(outputDir, `${output}.d.ts`),
-      format: 'es'
-    },
-    plugins: [
-      dts()
-    ]
-  }))
+      plugins: [
+        !config.browser && aliasPlugin,
+        config.browser && replacePlugin,
+        commonjs(),
+        nodeResolve(),
+        swc(defineRollupSwcOption({
+          jsc: {
+            externalHelpers: true,
+            parser: {
+              syntax: 'typescript',
+              tsx: true
+            },
+            transform: {
+              react: {
+                runtime: 'automatic',
+                importSource: '@emotion/react'
+              }
+            },
+            experimental: {
+              plugins: config.browser
+                ? []
+                : format === 'es'
+                  ? [esmTransformImportsPlugin]
+                  : [cjsTransformImportsPlugin]
+            }
+          }
+        }))
+      ]
+    })),
+    {
+      input,
+      output: {
+        file: resolve(outputDir, `${output}.d.ts`),
+        format: 'es'
+      },
+      plugins: [
+        dts()
+      ]
+    }
+  ]
 }
 
 const build: RollupOptions[] = [
-  buildMatrix('./src/index.tsx', 'index', {
+  ...buildMatrix('./src/index.tsx', 'index', {
     format: ['es', 'cjs'],
-    browser: false,
-    dts: true
+    browser: false
   }),
-  buildMatrix('./src/browser.tsx', 'browser', {
+  ...buildMatrix('./src/browser.tsx', 'browser', {
     format: ['es', 'umd'],
-    browser: true,
-    dts: true
-  }),
-  ...dtsMatrix()
+    browser: true
+  })
 ]
 
 export default build

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -113,6 +113,9 @@ const buildMatrix = (input: string, output: string, config: {
                     {
                       '@mui/material': {
                         transform: '@mui/material/{{member}}'
+                      },
+                      '@mui/material/styles': {
+                        transform: '@mui/material/styles/{{member}}'
                       }
                     }
                   ]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,5 @@
-import {
-  createTheme, Paper,
-  ThemeProvider
-} from '@mui/material'
+import { Paper } from '@mui/material'
+import { createTheme, ThemeProvider } from '@mui/material/styles'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { DataKeyPair } from './components/DataKeyPair'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,6 +1721,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/plugin-transform-imports@npm:^1.5.36":
+  version: 1.5.36
+  resolution: "@swc/plugin-transform-imports@npm:1.5.36"
+  checksum: b47cbb9bdd29d20ac391050ac19afe862cc3bd86c17de5405789ff2e815e710d4ad2ab3356427c73a0b6da11f8757f707171cbd2ad325970f29af525dfb654e2
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:^8.5.0":
   version: 8.18.1
   resolution: "@testing-library/dom@npm:8.18.1"
@@ -1784,6 +1791,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^15.0.1
     "@rollup/plugin-replace": ^5.0.2
     "@swc/core": ^1.3.27
+    "@swc/plugin-transform-imports": ^1.5.36
     "@testing-library/react": ^13.4.0
     "@types/node": ^18.11.18
     "@types/react": ^18.0.27


### PR DESCRIPTION
related: #140 #168

This PR introduced [@swc/plugin-transform-imports](https://github.com/swc-project/plugins/blob/main/packages/transform-imports/README.md) to [minimize](https://mui.com/material-ui/guides/minimizing-bundle-size/) the bundle size of MUI.

It will transform the import statement into path import to reduce the amount of modules being pulled in.
```js
import { Box, SvgIcon } from '@mui/material'
->
import Box from '@mui/material/Box'
import SvgIcon from '@mui/material/SvgIcon'