### PR TITLE
docs: remove deprecated `titleSuffix`

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -1,12 +1,4 @@
-import { useRouter } from 'next/router'
-
 export default {
-  titleSuffix: () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { route } = useRouter()
-    if (route === '/') return ''
-    return ' – Json Viewer'
-  },
   logo: '@textea/json-viewer',
   project: {
     link: 'https://github.com/TexteaInc/json-viewer'


### PR DESCRIPTION
See [nextra-theme-blog@2.0.2](https://github.com/shuding/nextra/releases/tag/nextra-theme-blog%402.0.2)