### PR TITLE
fix(dep)!: move `emotion` and `mui` to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ This is a React component for JSON viewer, but not only a JSON viewer.
 
 ## Usage
 
+`@textea/json-viewer` is using [Material-UI](https://mui.com/) as the base component library, so you need to install it and its peer dependencies first.
+
 ### NPM
 
 ```shell
-npm install @textea/json-viewer
+npm install @textea/json-viewer @mui/material @emotion/react @emotion/styled
 ```
 
 ### Yarn

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -14,12 +14,14 @@ import { JsonViewerPreview } from '../components/JsonViewerPreview'
 
 ### Installation
 
+`@textea/json-viewer` is using [Material-UI](https://mui.com/) as the base component library, so you need to install it and its peer dependencies first.
+
 ```shell
-npm install @textea/json-viewer
+npm install @textea/json-viewer @mui/material @emotion/react @emotion/styled
 # or
-yarn add @textea/json-viewer
+yarn add @textea/json-viewer @mui/material @emotion/react @emotion/styled
 # or
-pnpm add @textea/json-viewer
+pnpm add @textea/json-viewer @mui/material @emotion/react @emotion/styled
 ```
 
 You can also use it directly from a CDN:

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
     "build": "tsc && rollup -c rollup.config.ts --configPlugin swc3"
   },
   "dependencies": {
-    "@emotion/react": "^11.10.6",
-    "@emotion/styled": "^11.10.6",
     "@mui/material": "^5.11.15",
     "clsx": "^1.2.1",
     "copy-to-clipboard": "^3.3.3",
@@ -73,12 +71,16 @@
     "*.{ts,tsx,js,jsx}": "npx eslint --cache --fix"
   },
   "peerDependencies": {
+    "@emotion/react": "^11",
+    "@emotion/styled": "^11",
     "react": "^17 || ^18",
     "react-dom": "^17 || ^18"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.5.1",
     "@commitlint/config-angular": "^17.4.4",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
     "@rollup/plugin-alias": "^4.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "build": "tsc && rollup -c rollup.config.ts --configPlugin swc3"
   },
   "dependencies": {
-    "@mui/material": "^5.11.15",
     "clsx": "^1.2.1",
     "copy-to-clipboard": "^3.3.3",
     "zustand": "^4.3.7"
@@ -73,6 +72,7 @@
   "peerDependencies": {
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
+    "@mui/material": "^5",
     "react": "^17 || ^18",
     "react-dom": "^17 || ^18"
   },
@@ -81,6 +81,7 @@
     "@commitlint/config-angular": "^17.4.4",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
+    "@mui/material": "^5.11.15",
     "@rollup/plugin-alias": "^4.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,7 +1,6 @@
 /// <reference types="node" />
 import { basename, resolve } from 'node:path'
 
-import alias from '@rollup/plugin-alias'
 import commonjs from '@rollup/plugin-commonjs'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
@@ -22,10 +21,6 @@ const dtsOutput = new Set<[string, string]>()
 const outputDir = fileURLToPath(new URL('dist', import.meta.url))
 
 const external = [
-  '@emotion/react',
-  '@emotion/styled',
-  '@emotion/react/jsx-runtime',
-  '@emotion/react/jsx-dev-runtime',
   '@mui/material',
   '@mui/material/styles',
   'copy-to-clipboard',
@@ -65,21 +60,6 @@ const buildMatrix = (input: string, output: string, config: {
     cache,
     external: config.browser ? [] : external,
     plugins: [
-      alias({
-        entries: config.browser
-          ? []
-          : [
-              { find: 'react', replacement: '@emotion/react' },
-              {
-                find: 'react/jsx-dev-runtime',
-                replacement: '@emotion/react/jsx-dev-runtime'
-              },
-              {
-                find: 'react/jsx-runtime',
-                replacement: '@emotion/react/jsx-runtime'
-              }
-            ]
-      }),
       config.browser && replace({
         preventAssignment: true,
         'process.env.NODE_ENV': JSON.stringify('production'),
@@ -96,8 +76,7 @@ const buildMatrix = (input: string, output: string, config: {
           },
           transform: {
             react: {
-              runtime: 'automatic',
-              importSource: '@emotion/react'
+              runtime: 'automatic'
             }
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": "./src/",
     "jsx": "react-jsx",
     "strict": true,
-    "jsxImportSource": "@emotion/react",
     "incremental": false,
     "declaration": true,
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,6 +1746,7 @@ __metadata:
   peerDependencies:
     "@emotion/react": ^11
     "@emotion/styled": ^11
+    "@mui/material": ^5
     react: ^17 || ^18
     react-dom: ^17 || ^18
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,6 +1744,8 @@ __metadata:
     vitest: ^0.29.8
     zustand: ^4.3.7
   peerDependencies:
+    "@emotion/react": ^11
+    "@emotion/styled": ^11
     react: ^17 || ^18
     react-dom: ^17 || ^18
   languageName: unknown


### PR DESCRIPTION
https://emotion.sh/docs/for-library-authors

> If you do choose to use Emotion in your library, it is best to list the Emotion packages as peer dependencies in your package.json. This ensures that your library and the consuming application get the same instance of each Emotion package.

@pionxzh @rtritto 