### PR TITLE
docs: fix type file broken link in home page

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -40,7 +40,7 @@ const Component = () => (<JsonViewer value={object}/>)
 
 ### Type Declaration
 
-see [src/type.ts](../../src/type.ts)
+see [src/type.ts](https://github.com/TexteaInc/json-viewer/blob/main/src/type.ts)
 
 ### Full Example
 


### PR DESCRIPTION
This PR fix the broken link in home page of `types.ts` file.