### PR TITLE
fix: correct types reference for module projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./src/type.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
There is an incorrect reference in the `package.json` as the `src` folder is not published to npm, which gives an error when using it inside a project with `type: module`

`Could not find a declaration file for module '@textea/json-viewer'. 'D:/DEV/DEVOPS/gerald/node_modules/@textea/json-viewer/dist/index.mjs' implicitly has an 'any' type.`
