### PR TITLE
fix: improve copying on circular reference / BigInt / Map / Set

### DIFF
--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from 'react'
 
 import { useJsonViewerStore } from '../stores/JsonViewerStore'
 import type { JsonViewerOnCopy } from '../type'
+import { circularStringify } from '../utils'
 
 /**
  * useClipboard hook accepts one argument options in which copied status timeout duration is defined (defaults to 2000). Hook returns object with properties:
@@ -51,9 +52,8 @@ export function useClipboard ({ timeout = 2000 } = {}) {
           }]`, error)
       }
     } else {
-      const valueToCopy = JSON.stringify(
+      const valueToCopy = circularStringify(
         typeof value === 'function' ? value.toString() : value,
-        null,
         '  '
       )
       if ('clipboard' in navigator) {

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState } from 'react'
 
 import { useJsonViewerStore } from '../stores/JsonViewerStore'
 import type { JsonViewerOnCopy } from '../type'
-import { circularStringify } from '../utils'
+import { safeStringify } from '../utils'
 
 /**
  * useClipboard hook accepts one argument options in which copied status timeout duration is defined (defaults to 2000). Hook returns object with properties:
@@ -52,7 +52,7 @@ export function useClipboard ({ timeout = 2000 } = {}) {
           }]`, error)
       }
     } else {
-      const valueToCopy = circularStringify(
+      const valueToCopy = safeStringify(
         typeof value === 'function' ? value.toString() : value,
         '  '
       )

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -150,3 +150,23 @@ export function segmentArray<T> (arr: T[], size: number): T[][] {
   }
   return result
 }
+
+// https://stackoverflow.com/a/72457899
+export function circularStringify (obj: any, space?: string | number) {
+  const seenValues = []
+
+  function circularReplacer (key: string | number, value: any) {
+    if (typeof value === 'object' && value !== null && Object.keys(value).length) {
+      const stackSize = seenValues.length
+      if (stackSize) {
+        // clean up expired references
+        for (let n = stackSize - 1; seenValues[n][key] !== value; --n) { seenValues.pop() }
+        if (seenValues.includes(value)) return '[Circular]'
+      }
+      seenValues.push(value)
+    }
+    return value
+  }
+
+  return JSON.stringify(obj, circularReplacer, space)
+}


### PR DESCRIPTION
Circular Reference -> `[Circular]`, close #225 
BigInt -> `"123456789123"`
Map -> `Object` if all of key are `string` or `number`
Set -> `Array`