### PR TITLE
feat: highlight changed

### DIFF
--- a/docs/pages/full/index.tsx
+++ b/docs/pages/full/index.tsx
@@ -120,6 +120,7 @@ const IndexPage: FC = () => {
   const [displayDataTypes, setDisplayDataTypes] = useState(true)
   const [displayObjectSize, setDisplayObjectSize] = useState(true)
   const [editable, setEditable] = useState(true)
+  const [highlightUpdates, setHighlightUpdates] = useState(true)
   useEffect(() => {
     const loop = () => {
       setSrc(src => ({
@@ -165,6 +166,15 @@ const IndexPage: FC = () => {
             />
           )}
           label='Editable'
+        />
+        <FormControlLabel
+          control={(
+            <Switch
+              checked={highlightUpdates}
+              onChange={event => setHighlightUpdates(event.target.checked)}
+            />
+          )}
+          label='Highlight Updates'
         />
         <FormControlLabel
           control={(
@@ -239,6 +249,7 @@ const IndexPage: FC = () => {
       <JsonViewer
         value={src}
         editable={editable}
+        highlightUpdates={highlightUpdates}
         indentWidth={indent}
         theme={theme}
         displayDataTypes={displayDataTypes}

--- a/src/components/DataTypes/Object.tsx
+++ b/src/components/DataTypes/Object.tsx
@@ -136,6 +136,7 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
               key={key}
               path={path}
               value={value}
+              prevValue={props.prevValue instanceof Map ? props.prevValue.get(k) : undefined}
               editable={false}
             />
           )
@@ -167,7 +168,12 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
         const elements = value.slice(0, displayLength).map((value, index) => {
           const path = [...props.path, index]
           return (
-            <DataKeyPair key={index} path={path} value={value} />
+            <DataKeyPair
+              key={index}
+              path={path}
+              value={value}
+              prevValue={Array.isArray(props.prevValue) ? props.prevValue[index] : undefined}
+            />
           )
         })
         if (value.length > displayLength) {
@@ -193,6 +199,7 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
       }
 
       const elements: unknown[][] = segmentArray(value, groupArraysAfterLength)
+      const prevElements = Array.isArray(props.prevValue) ? segmentArray(props.prevValue, groupArraysAfterLength) : undefined
 
       return elements.map((list, index) => {
         const path = [...props.path]
@@ -202,6 +209,7 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
             path={path}
             value={list}
             nestedIndex={index}
+            prevValue={prevElements?.[index]}
           />
         )
       })
@@ -216,7 +224,7 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
     const elements = entries.slice(0, displayLength).map(([key, value]) => {
       const path = [...props.path, key]
       return (
-        <DataKeyPair key={key} path={path} value={value} />
+        <DataKeyPair key={key} path={path} value={value} prevValue={(props.prevValue as any)?.[key]} />
       )
     })
     if (entries.length > displayLength) {
@@ -242,6 +250,7 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
   }, [
     props.inspect,
     props.value,
+    props.prevValue,
     props.path,
     groupArraysAfterLength,
     displayLength,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,12 @@ function useSetIfNotUndefinedEffect<Key extends keyof JsonViewerProps> (
  */
 const JsonViewerInner: FC<JsonViewerProps> = (props) => {
   const { setState } = useContext(JsonViewerStoreContext)
-  useSetIfNotUndefinedEffect('value', props.value)
+  useEffect(() => {
+    setState((state) => ({
+      prevValue: state.value,
+      value: props.value
+    }))
+  }, [props.value, setState])
   useSetIfNotUndefinedEffect('editable', props.editable)
   useSetIfNotUndefinedEffect('indentWidth', props.indentWidth)
   useSetIfNotUndefinedEffect('onChange', props.onChange)
@@ -55,6 +60,7 @@ const JsonViewerInner: FC<JsonViewerProps> = (props) => {
   useSetIfNotUndefinedEffect('keyRenderer', props.keyRenderer)
   useSetIfNotUndefinedEffect('maxDisplayLength', props.maxDisplayLength)
   useSetIfNotUndefinedEffect('enableClipboard', props.enableClipboard)
+  useSetIfNotUndefinedEffect('highlightUpdates', props.highlightUpdates)
   useSetIfNotUndefinedEffect('rootName', props.rootName)
   useSetIfNotUndefinedEffect('displayDataTypes', props.displayDataTypes)
   useSetIfNotUndefinedEffect('displayObjectSize', props.displayObjectSize)
@@ -97,6 +103,7 @@ const JsonViewerInner: FC<JsonViewerProps> = (props) => {
   }, [props.valueTypes, predefinedTypes, registerTypes])
 
   const value = useJsonViewerStore(store => store.value)
+  const prevValue = useJsonViewerStore(store => store.prevValue)
   const setHover = useJsonViewerStore(store => store.setHover)
   const onMouseLeave = useCallback(() => setHover(null), [setHover])
   return (
@@ -114,6 +121,7 @@ const JsonViewerInner: FC<JsonViewerProps> = (props) => {
     >
       <DataKeyPair
         value={value}
+        prevValue={prevValue}
         path={useMemo(() => [], [])}
       />
     </Paper>

--- a/src/stores/JsonViewerStore.ts
+++ b/src/stores/JsonViewerStore.ts
@@ -23,6 +23,7 @@ export type JsonViewerState<T = unknown> = {
   indentWidth: number
   groupArraysAfterLength: number
   enableClipboard: boolean
+  highlightUpdates: boolean
   maxDisplayLength: number
   defaultInspectDepth: number
   collapseStringsAfterLength: number
@@ -32,6 +33,7 @@ export type JsonViewerState<T = unknown> = {
   editable: boolean | (<U>(path: Path, currentValue: U) => boolean)
   displayDataTypes: boolean
   rootName: false | string
+  prevValue: T | undefined
   value: T
   onChange: JsonViewerOnChange
   onCopy: JsonViewerOnCopy | undefined
@@ -49,6 +51,7 @@ export const createJsonViewerStore = <T = unknown> (props: JsonViewerProps<T>) =
   return create<JsonViewerState>()((set, get) => ({
     // provided by user
     enableClipboard: props.enableClipboard ?? true,
+    highlightUpdates: props.highlightUpdates ?? false,
     indentWidth: props.indentWidth ?? 3,
     groupArraysAfterLength: props.groupArraysAfterLength ?? 100,
     collapseStringsAfterLength:
@@ -71,6 +74,7 @@ export const createJsonViewerStore = <T = unknown> (props: JsonViewerProps<T>) =
     hoverPath: null,
     colorspace: lightColorspace,
     value: props.value,
+    prevValue: undefined,
     displayObjectSize: props.displayObjectSize ?? true,
 
     getInspectCache: (path, nestedIndex) => {

--- a/src/type.ts
+++ b/src/type.ts
@@ -36,6 +36,7 @@ export interface DataItemProps<ValueType = unknown> {
   inspect: boolean
   setInspect: Dispatch<SetStateAction<boolean>>
   value: ValueType
+  prevValue: ValueType | undefined
   path: Path
 }
 
@@ -168,4 +169,11 @@ export type JsonViewerProps<T = unknown> = {
    * @default true
    */
   displayObjectSize?: boolean
+
+  /**
+   * Whether to highlight updates.
+   *
+   * @default false
+   */
+  highlightUpdates?: boolean
 }


### PR DESCRIPTION
Add a highlighting effect to the key of the changed data.

> Shortcoming: Because the value is only compared within the `<DataKeyPair />` component, highlighting only display at the deepest key where changed. Adding and removing properties do not cause highlighting.

## Add Option

* enableHighlight: Whether to highlight the changed

## Screenshot

![](https://user-images.githubusercontent.com/13579374/226986898-62069263-c289-4408-bfff-9c52b5eca198.gif)

Feel free to make your requests and suggestions.

close #267 