### PR TITLE
feat: expose built-in types

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ see [src/type.ts](src/type.ts)
 
 ### Basic Example
 
-```tsx
+```jsx
 import { JsonViewer } from '@textea/json-viewer'
 
 const object = {
@@ -55,8 +55,8 @@ const Component = () => <JsonViewer value={object} />
 
 ### Customizable data type
 
-```tsx
-import { JsonViewer, createDataType } from '@textea/json-viewer'
+```jsx
+import { JsonViewer, defineDataType } from '@textea/json-viewer'
 
 const object = {
   // what if I want to inspect a image?
@@ -73,10 +73,10 @@ const Component = () => (
         Component: (props) => <Image height={50} width={50} src={props.value} alt={props.value} />
       },
       // or
-      createDataType(
-        (value) => typeof value === 'string' && value.startsWith('https://i.imgur.com'),
-        (props) => <Image height={50} width={50} src={props.value} alt={props.value} />
-      )
+      defineDataType({
+        is: (value) => typeof value === 'string' && value.startsWith('https://i.imgur.com'),
+        Component: (props) => <Image height={50} width={50} src={props.value} alt={props.value} />
+      })
     ]}
   />
 )

--- a/docs/pages/full/index.tsx
+++ b/docs/pages/full/index.tsx
@@ -20,7 +20,7 @@ import type {
 } from '@textea/json-viewer'
 import {
   applyValue,
-  createDataType,
+  defineDataType,
   JsonViewer,
   stringType
 } from '@textea/json-viewer'
@@ -44,8 +44,8 @@ const aPlusBConst = function (a: number, b: number) {
 }
 
 const loopObject = {
-  foo: 1,
-  goo: 'string'
+  foo: 42,
+  goo: 'Lorem Ipsum'
 } as Record<string, any>
 
 loopObject.self = loopObject
@@ -67,30 +67,35 @@ const set = new Set([1, 2, 3])
 const superLongString = '1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111'
 
 const example = {
+  avatar,
+  string: 'Lorem ipsum dolor sit amet',
+  integer: 42,
+  float: 114.514,
+  bigint: 123456789087654321n,
+  undefined,
+  timer: 0,
+  date: new Date('Tue Sep 13 2022 14:07:44 GMT-0500 (Central Daylight Time)'),
+  link: 'http://example.com',
+  emptyArray: [],
+  array: [19, 19, 810, 'test', NaN],
+  emptyObject: {},
+  object: {
+    foo: true,
+    bar: false,
+    last: null
+  },
+  emptyMap: new Map(),
+  map,
+  emptySet: new Set(),
+  set,
   loopObject,
   loopArray,
   longArray,
-  string: 'this is a string',
-  integer: 42,
-  array: [19, 19, 810, 'test', NaN],
-  emptyArray: [],
   nestedArray: [
     [1, 2],
     [3, 4]
   ],
-  map,
-  emptyMap: new Map(),
-  set,
-  emptySet: new Set(),
-  float: 114.514,
-  undefined,
   superLongString,
-  object: {
-    'first-child': true,
-    'second-child': false,
-    'last-child': null
-  },
-  emptyObject: {},
   function: aPlusB,
   constFunction: aPlusBConst,
   anonymousFunction: function (a: number, b: number) {
@@ -101,12 +106,7 @@ const example = {
     console.log(arg1, arg2)
     return '123'
   },
-  string_number: '1234',
-  timer: 0,
-  link: 'http://example.com',
-  avatar,
-  date: new Date('Tue Sep 13 2022 14:07:44 GMT-0500 (Central Daylight Time)'),
-  bigint: 123456789087654321n
+  string_number: '1234'
 }
 
 const KeyRenderer: JsonViewerKeyRenderer = ({ path }) => {
@@ -116,8 +116,8 @@ const KeyRenderer: JsonViewerKeyRenderer = ({ path }) => {
 }
 KeyRenderer.when = (props) => props.value === 114.514
 
-const imageDataType = createDataType<string>(
-  (value) => {
+const imageDataType = defineDataType<string>({
+  is: (value) => {
     if (typeof value === 'string') {
       try {
         const url = new URL(value)
@@ -128,17 +128,18 @@ const imageDataType = createDataType<string>(
     }
     return false
   },
-  (props) => {
+  Component: (props) => {
     return (
       <Image
-        height={50}
-        width={50}
+        height={48}
+        width={48}
         src={props.value}
         alt={props.value}
+        style={{ display: 'inline-block' }}
       />
     )
   }
-)
+})
 
 const LinkIcon = (props: SvgIconProps) => (
   // <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' strokeWidth='2' stroke='currentColor' fill='none' strokeLinecap='round' strokeLinejoin='round'>
@@ -163,7 +164,7 @@ const linkType: DataType<string> = {
       textDecoration: 'underline'
     }}
     >
-      <Link href={props.value}>
+      <Link href={props.value} target='_blank' rel='noopener noreferrer'>
         Open
         <LinkIcon sx={{ strokeWidth: 2 }} />
       </Link>

--- a/src/components/DataTypes/Boolean.tsx
+++ b/src/components/DataTypes/Boolean.tsx
@@ -1,0 +1,15 @@
+
+import type { DataType } from '../../type'
+import { createEasyType } from './createEasyType'
+
+export const booleanType: DataType<boolean> = {
+  is: (value) => typeof value === 'boolean',
+  ...createEasyType(
+    'bool',
+    ({ value }) => <>{value ? 'true' : 'false'}</>,
+    {
+      colorKey: 'base0E',
+      fromString: value => Boolean(value)
+    }
+  )
+}

--- a/src/components/DataTypes/Boolean.tsx
+++ b/src/components/DataTypes/Boolean.tsx
@@ -1,15 +1,15 @@
 
-import type { DataType } from '../../type'
 import { createEasyType } from './createEasyType'
 
-export const booleanType: DataType<boolean> = {
+export const booleanType = createEasyType<boolean>({
   is: (value) => typeof value === 'boolean',
-  ...createEasyType(
-    'bool',
-    ({ value }) => <>{value ? 'true' : 'false'}</>,
-    {
-      colorKey: 'base0E',
-      fromString: value => Boolean(value)
-    }
-  )
-}
+  type: 'bool',
+  colorKey: 'base0E',
+  serialize: value => value.toString(),
+  deserialize: value => {
+    if (value === 'true') return true
+    if (value === 'false') return false
+    throw new Error('Invalid boolean value')
+  },
+  Renderer: ({ value }) => <>{value ? 'true' : 'false'}</>
+})

--- a/src/components/DataTypes/Date.tsx
+++ b/src/components/DataTypes/Date.tsx
@@ -1,0 +1,23 @@
+
+import type { DataType } from '../../type'
+import { createEasyType } from './createEasyType'
+
+const displayOptions: Intl.DateTimeFormatOptions = {
+  weekday: 'short',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+}
+
+export const dateType: DataType<Date> = {
+  is: (value) => value instanceof Date,
+  ...createEasyType(
+    'date',
+    ({ value }) => <>{value.toLocaleTimeString('en-us', displayOptions)}</>,
+    {
+      colorKey: 'base0D'
+    }
+  )
+}

--- a/src/components/DataTypes/Date.tsx
+++ b/src/components/DataTypes/Date.tsx
@@ -1,5 +1,4 @@
 
-import type { DataType } from '../../type'
 import { createEasyType } from './createEasyType'
 
 const displayOptions: Intl.DateTimeFormatOptions = {
@@ -11,13 +10,9 @@ const displayOptions: Intl.DateTimeFormatOptions = {
   minute: '2-digit'
 }
 
-export const dateType: DataType<Date> = {
+export const dateType = createEasyType<Date>({
   is: (value) => value instanceof Date,
-  ...createEasyType(
-    'date',
-    ({ value }) => <>{value.toLocaleTimeString('en-us', displayOptions)}</>,
-    {
-      colorKey: 'base0D'
-    }
-  )
-}
+  type: 'date',
+  colorKey: 'base0D',
+  Renderer: ({ value }) => <>{value.toLocaleTimeString('en-us', displayOptions)}</>
+})

--- a/src/components/DataTypes/Function.tsx
+++ b/src/components/DataTypes/Function.tsx
@@ -6,7 +6,7 @@ import { Box, NoSsr } from '@mui/material'
 import type { FC } from 'react'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'
-import type { DataItemProps } from '../../type'
+import type { DataItemProps, DataType } from '../../type'
 import { DataTypeLabel } from '../DataTypeLabel'
 
 const functionBody = (func: Function) => {
@@ -41,7 +41,7 @@ const functionName = (func: Function) => {
 const lb = '{'
 const rb = '}'
 
-export const PreFunctionType: FC<DataItemProps<Function>> = (props) => {
+const PreFunctionType: FC<DataItemProps<Function>> = (props) => {
   return (
     <NoSsr>
       <DataTypeLabel dataType='function' />
@@ -59,7 +59,7 @@ export const PreFunctionType: FC<DataItemProps<Function>> = (props) => {
   )
 }
 
-export const PostFunctionType: FC<DataItemProps<Function>> = () => {
+const PostFunctionType: FC<DataItemProps<Function>> = () => {
   return (
     <NoSsr>
       <Box component='span' className='data-function-end'>
@@ -69,7 +69,7 @@ export const PostFunctionType: FC<DataItemProps<Function>> = () => {
   )
 }
 
-export const FunctionType: FC<DataItemProps<Function>> = (props) => {
+const FunctionType: FC<DataItemProps<Function>> = (props) => {
   const functionColor = useJsonViewerStore(store => store.colorspace.base05)
   return (
     <NoSsr>
@@ -99,4 +99,11 @@ export const FunctionType: FC<DataItemProps<Function>> = (props) => {
       </Box>
     </NoSsr>
   )
+}
+
+export const functionType: DataType<Function> = {
+  is: (value) => typeof value === 'function',
+  Component: FunctionType,
+  PreComponent: PreFunctionType,
+  PostComponent: PostFunctionType
 }

--- a/src/components/DataTypes/Null.tsx
+++ b/src/components/DataTypes/Null.tsx
@@ -1,32 +1,27 @@
 import { Box } from '@mui/material'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'
-import type { DataType } from '../../type'
 import { createEasyType } from './createEasyType'
 
-export const nullType: DataType<null> = {
+export const nullType = createEasyType<null>({
   is: (value) => value === null,
-  ...createEasyType(
-    'null',
-    () => {
-      const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
-      return (
-        <Box
-          sx={{
-            fontSize: '0.8rem',
-            backgroundColor,
-            fontWeight: 'bold',
-            borderRadius: '3px',
-            padding: '0.5px 2px'
-          }}
-        >
-          NULL
-        </Box>
-      )
-    },
-    {
-      colorKey: 'base08',
-      displayTypeLabel: false
-    }
-  )
-}
+  type: 'null',
+  colorKey: 'base08',
+  displayTypeLabel: false,
+  Renderer: () => {
+    const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
+    return (
+      <Box
+        sx={{
+          fontSize: '0.8rem',
+          backgroundColor,
+          fontWeight: 'bold',
+          borderRadius: '3px',
+          padding: '0.5px 2px'
+        }}
+      >
+        NULL
+      </Box>
+    )
+  }
+})

--- a/src/components/DataTypes/Null.tsx
+++ b/src/components/DataTypes/Null.tsx
@@ -1,0 +1,32 @@
+import { Box } from '@mui/material'
+
+import { useJsonViewerStore } from '../../stores/JsonViewerStore'
+import type { DataType } from '../../type'
+import { createEasyType } from './createEasyType'
+
+export const nullType: DataType<null> = {
+  is: (value) => value === null,
+  ...createEasyType(
+    'null',
+    () => {
+      const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
+      return (
+        <Box
+          sx={{
+            fontSize: '0.8rem',
+            backgroundColor,
+            fontWeight: 'bold',
+            borderRadius: '3px',
+            padding: '0.5px 2px'
+          }}
+        >
+          NULL
+        </Box>
+      )
+    },
+    {
+      colorKey: 'base08',
+      displayTypeLabel: false
+    }
+  )
+}

--- a/src/components/DataTypes/Number.tsx
+++ b/src/components/DataTypes/Number.tsx
@@ -1,69 +1,60 @@
 import { Box } from '@mui/material'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'
-import type { DataType } from '../../type'
 import { createEasyType } from './createEasyType'
 
 const isInt = (n: number) => n % 1 === 0
 
-export const nanType: DataType<number> = {
+export const nanType = createEasyType<number>({
   is: (value) => typeof value === 'number' && isNaN(value),
-  ...createEasyType(
-    'NaN',
-    () => {
-      const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
-      return (
-        <Box
-          sx={{
-            backgroundColor,
-            fontSize: '0.8rem',
-            fontWeight: 'bold',
-            borderRadius: '3px'
-          }}
-        >
-          NaN
-        </Box>
-      )
-    },
-    {
-      colorKey: 'base08',
-      displayTypeLabel: false
-    }
-  )
-}
+  type: 'NaN',
+  colorKey: 'base08',
+  displayTypeLabel: false,
+  serialize: () => 'NaN',
+  // allow deserialize the value back to number
+  deserialize: (value) => parseFloat(value),
+  Renderer: () => {
+    const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
+    return (
+      <Box
+        sx={{
+          backgroundColor,
+          fontSize: '0.8rem',
+          fontWeight: 'bold',
+          borderRadius: '3px',
+          padding: '0.5px 2px'
+        }}
+      >
+        NaN
+      </Box>
+    )
+  }
+})
 
-export const floatType: DataType<number> = {
-  is: (value) => typeof value === 'number' && !isInt(value),
-  ...createEasyType(
-    'float',
-    ({ value }) => <>{value}</>,
-    {
-      colorKey: 'base0B',
-      fromString: value => parseFloat(value)
-    }
-  )
-}
+export const floatType = createEasyType<number>({
+  is: (value) => typeof value === 'number' && !isInt(value) && !isNaN(value),
+  type: 'float',
+  colorKey: 'base0B',
+  serialize: value => value.toString(),
+  deserialize: value => parseFloat(value),
+  Renderer: ({ value }) => <>{value}</>
+})
 
-export const intType: DataType<number> = {
+export const intType = createEasyType<number>({
   is: (value) => typeof value === 'number' && isInt(value),
-  ...createEasyType(
-    'int',
-    ({ value }) => <>{value}</>,
-    {
-      colorKey: 'base0F',
-      fromString: value => parseInt(value)
-    }
-  )
-}
+  type: 'int',
+  colorKey: 'base0F',
+  serialize: value => value.toString(),
+  // allow deserialize the value to float
+  deserialize: value => parseFloat(value),
+  Renderer: ({ value }) => <>{value}</>
+})
 
-export const bigIntType: DataType<bigint> = {
+export const bigIntType = createEasyType<bigint>({
   is: (value) => typeof value === 'bigint',
-  ...createEasyType(
-    'bigint',
-    ({ value }) => <>{`${value}n`}</>,
-    {
-      colorKey: 'base0F',
-      fromString: value => BigInt(value.replace(/\D/g, ''))
-    }
-  )
-}
+  type: 'bigint',
+  colorKey: 'base0F',
+  serialize: value => value.toString(),
+  deserialize: value => BigInt(value.replace(/\D/g, '')),
+  Renderer: ({ value }) => <>{`${value}n`}</>
+})

--- a/src/components/DataTypes/Number.tsx
+++ b/src/components/DataTypes/Number.tsx
@@ -1,0 +1,69 @@
+import { Box } from '@mui/material'
+
+import { useJsonViewerStore } from '../../stores/JsonViewerStore'
+import type { DataType } from '../../type'
+import { createEasyType } from './createEasyType'
+
+const isInt = (n: number) => n % 1 === 0
+
+export const nanType: DataType<number> = {
+  is: (value) => typeof value === 'number' && isNaN(value),
+  ...createEasyType(
+    'NaN',
+    () => {
+      const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
+      return (
+        <Box
+          sx={{
+            backgroundColor,
+            fontSize: '0.8rem',
+            fontWeight: 'bold',
+            borderRadius: '3px'
+          }}
+        >
+          NaN
+        </Box>
+      )
+    },
+    {
+      colorKey: 'base08',
+      displayTypeLabel: false
+    }
+  )
+}
+
+export const floatType: DataType<number> = {
+  is: (value) => typeof value === 'number' && !isInt(value),
+  ...createEasyType(
+    'float',
+    ({ value }) => <>{value}</>,
+    {
+      colorKey: 'base0B',
+      fromString: value => parseFloat(value)
+    }
+  )
+}
+
+export const intType: DataType<number> = {
+  is: (value) => typeof value === 'number' && isInt(value),
+  ...createEasyType(
+    'int',
+    ({ value }) => <>{value}</>,
+    {
+      colorKey: 'base0F',
+      fromString: value => parseInt(value)
+    }
+  )
+}
+
+export const bigIntType: DataType<bigint> = {
+  is: (value) => typeof value === 'bigint',
+  ...createEasyType(
+    'bigint',
+    ({ value }) => <>{`${value}n`}</>,
+    {
+      colorKey: 'base0F',
+      fromString: value => BigInt(value.replace(/\D/g, ''))
+    }
+  )
+}

--- a/src/components/DataTypes/Object.tsx
+++ b/src/components/DataTypes/Object.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react'
 import { useTextColor } from '../../hooks/useColor'
 import { useIsCycleReference } from '../../hooks/useIsCycleReference'
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'
-import type { DataItemProps } from '../../type'
+import type { DataItemProps, DataType } from '../../type'
 import { getValueSize, segmentArray } from '../../utils'
 import { DataKeyPair } from '../DataKeyPair'
 import { CircularArrowsIcon } from '../Icons'
@@ -29,7 +29,7 @@ function inspectMetadata (value: object) {
   return `${length} Items${name ? ` (${name})` : ''}`
 }
 
-export const PreObjectType: FC<DataItemProps<object>> = (props) => {
+const PreObjectType: FC<DataItemProps<object>> = (props) => {
   const metadataColor = useJsonViewerStore(store => store.colorspace.base04)
   const textColor = useTextColor()
   const isArray = useMemo(() => Array.isArray(props.value), [props.value])
@@ -77,7 +77,7 @@ export const PreObjectType: FC<DataItemProps<object>> = (props) => {
   )
 }
 
-export const PostObjectType: FC<DataItemProps<object>> = (props) => {
+const PostObjectType: FC<DataItemProps<object>> = (props) => {
   const metadataColor = useJsonViewerStore(store => store.colorspace.base04)
   const isArray = useMemo(() => Array.isArray(props.value), [props.value])
   const displayObjectSize = useJsonViewerStore(store => store.displayObjectSize)
@@ -110,7 +110,7 @@ function getIterator (value: any): value is Iterable<unknown> {
   return typeof value?.[Symbol.iterator] === 'function'
 }
 
-export const ObjectType: FC<DataItemProps<object>> = (props) => {
+const ObjectType: FC<DataItemProps<object>> = (props) => {
   const keyColor = useTextColor()
   const borderColor = useJsonViewerStore(store => store.colorspace.base02)
   const groupArraysAfterLength = useJsonViewerStore(store => store.groupArraysAfterLength)
@@ -295,4 +295,11 @@ export const ObjectType: FC<DataItemProps<object>> = (props) => {
       }
     </Box>
   )
+}
+
+export const objectType: DataType<object> = {
+  is: (value) => typeof value === 'object',
+  Component: ObjectType,
+  PreComponent: PreObjectType,
+  PostComponent: PostObjectType
 }

--- a/src/components/DataTypes/String.tsx
+++ b/src/components/DataTypes/String.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material'
+import { useState } from 'react'
+
+import { useJsonViewerStore } from '../../stores/JsonViewerStore'
+import type { DataType } from '../../type'
+import { createEasyType } from './createEasyType'
+
+export const stringType: DataType<string> = {
+  is: (value) => typeof value === 'string',
+  ...createEasyType(
+    'string',
+    (props) => {
+      const [showRest, setShowRest] = useState(false)
+      const collapseStringsAfterLength = useJsonViewerStore(store => store.collapseStringsAfterLength)
+      const value = showRest
+        ? props.value
+        : props.value.slice(0, collapseStringsAfterLength)
+      const hasRest = props.value.length > collapseStringsAfterLength
+      return (
+        <Box
+          component='span'
+          sx={{
+            overflowWrap: 'anywhere',
+            cursor: hasRest ? 'pointer' : 'inherit'
+          }}
+          onClick={() => {
+            if (hasRest) {
+              setShowRest(value => !value)
+            }
+          }}
+        >
+          &quot;
+          {value}
+          {hasRest && !showRest && (<Box component='span' sx={{ padding: 0.5 }}>…</Box>)}
+          &quot;
+        </Box>
+      )
+    },
+    {
+      colorKey: 'base09',
+      fromString: value => value
+    }
+  )
+}

--- a/src/components/DataTypes/String.tsx
+++ b/src/components/DataTypes/String.tsx
@@ -2,43 +2,39 @@ import { Box } from '@mui/material'
 import { useState } from 'react'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'
-import type { DataType } from '../../type'
 import { createEasyType } from './createEasyType'
 
-export const stringType: DataType<string> = {
+export const stringType = createEasyType<string>({
   is: (value) => typeof value === 'string',
-  ...createEasyType(
-    'string',
-    (props) => {
-      const [showRest, setShowRest] = useState(false)
-      const collapseStringsAfterLength = useJsonViewerStore(store => store.collapseStringsAfterLength)
-      const value = showRest
-        ? props.value
-        : props.value.slice(0, collapseStringsAfterLength)
-      const hasRest = props.value.length > collapseStringsAfterLength
-      return (
-        <Box
-          component='span'
-          sx={{
-            overflowWrap: 'anywhere',
-            cursor: hasRest ? 'pointer' : 'inherit'
-          }}
-          onClick={() => {
-            if (hasRest) {
-              setShowRest(value => !value)
-            }
-          }}
-        >
-          &quot;
-          {value}
-          {hasRest && !showRest && (<Box component='span' sx={{ padding: 0.5 }}>…</Box>)}
-          &quot;
-        </Box>
-      )
-    },
-    {
-      colorKey: 'base09',
-      fromString: value => value
-    }
-  )
-}
+  type: 'string',
+  colorKey: 'base09',
+  serialize: value => value,
+  deserialize: value => value,
+  Renderer: (props) => {
+    const [showRest, setShowRest] = useState(false)
+    const collapseStringsAfterLength = useJsonViewerStore(store => store.collapseStringsAfterLength)
+    const value = showRest
+      ? props.value
+      : props.value.slice(0, collapseStringsAfterLength)
+    const hasRest = props.value.length > collapseStringsAfterLength
+    return (
+      <Box
+        component='span'
+        sx={{
+          overflowWrap: 'anywhere',
+          cursor: hasRest ? 'pointer' : 'inherit'
+        }}
+        onClick={() => {
+          if (hasRest) {
+            setShowRest(value => !value)
+          }
+        }}
+      >
+        &quot;
+        {value}
+        {hasRest && !showRest && (<Box component='span' sx={{ padding: 0.5 }}>…</Box>)}
+        &quot;
+      </Box>
+    )
+  }
+})

--- a/src/components/DataTypes/Undefined.tsx
+++ b/src/components/DataTypes/Undefined.tsx
@@ -1,31 +1,26 @@
 import { Box } from '@mui/material'
 
 import { useJsonViewerStore } from '../../stores/JsonViewerStore'
-import type { DataType } from '../../type'
 import { createEasyType } from './createEasyType'
 
-export const undefinedType: DataType<undefined> = {
+export const undefinedType = createEasyType<undefined>({
   is: (value) => value === undefined,
-  ...createEasyType(
-    'undefined',
-    () => {
-      const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
-      return (
-        <Box
-          sx={{
-            fontSize: '0.7rem',
-            backgroundColor,
-            borderRadius: '3px',
-            padding: '0.5px 2px'
-          }}
-        >
-          undefined
-        </Box>
-      )
-    },
-    {
-      colorKey: 'base05',
-      displayTypeLabel: false
-    }
-  )
-}
+  type: 'undefined',
+  colorKey: 'base05',
+  displayTypeLabel: false,
+  Renderer: () => {
+    const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
+    return (
+      <Box
+        sx={{
+          fontSize: '0.7rem',
+          backgroundColor,
+          borderRadius: '3px',
+          padding: '0.5px 2px'
+        }}
+      >
+        undefined
+      </Box>
+    )
+  }
+})

--- a/src/components/DataTypes/Undefined.tsx
+++ b/src/components/DataTypes/Undefined.tsx
@@ -1,0 +1,31 @@
+import { Box } from '@mui/material'
+
+import { useJsonViewerStore } from '../../stores/JsonViewerStore'
+import type { DataType } from '../../type'
+import { createEasyType } from './createEasyType'
+
+export const undefinedType: DataType<undefined> = {
+  is: (value) => value === undefined,
+  ...createEasyType(
+    'undefined',
+    () => {
+      const backgroundColor = useJsonViewerStore(store => store.colorspace.base02)
+      return (
+        <Box
+          sx={{
+            fontSize: '0.7rem',
+            backgroundColor,
+            borderRadius: '3px',
+            padding: '0.5px 2px'
+          }}
+        >
+          undefined
+        </Box>
+      )
+    },
+    {
+      colorKey: 'base05',
+      displayTypeLabel: false
+    }
+  )
+}

--- a/src/components/DataTypes/index.ts
+++ b/src/components/DataTypes/index.ts
@@ -1,0 +1,8 @@
+export { booleanType } from './Boolean'
+export { dateType } from './Date'
+export { functionType } from './Function'
+export { nullType } from './Null'
+export { bigIntType, floatType, intType, nanType } from './Number'
+export { objectType } from './Object'
+export { stringType } from './String'
+export { undefinedType } from './Undefined'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,15 +15,12 @@ import {
 } from './stores/JsonViewerStore'
 import {
   createTypeRegistryStore,
-  predefined,
+  predefinedTypes,
   TypeRegistryStoreContext,
   useTypeRegistryStore
 } from './stores/typeRegistry'
 import { darkColorspace, lightColorspace } from './theme/base16'
 import type { JsonViewerProps } from './type'
-import { applyValue, createDataType, isCycleReference } from './utils'
-
-export { applyValue, createDataType, isCycleReference }
 
 /**
  * @internal
@@ -86,7 +83,6 @@ const JsonViewerInner: FC<JsonViewerProps> = (props) => {
     return props.theme === 'dark' ? 'json-viewer-theme-dark' : 'json-viewer-theme-light'
   }, [props.theme])
   const onceRef = useRef(true)
-  const predefinedTypes = useMemo(() => predefined(), [])
   const registerTypes = useTypeRegistryStore(store => store.registerTypes)
   if (onceRef.current) {
     const allTypes = props.valueTypes
@@ -100,7 +96,7 @@ const JsonViewerInner: FC<JsonViewerProps> = (props) => {
       ? [...predefinedTypes, ...props.valueTypes]
       : [...predefinedTypes]
     registerTypes(allTypes)
-  }, [props.valueTypes, predefinedTypes, registerTypes])
+  }, [props.valueTypes, registerTypes])
 
   const value = useJsonViewerStore(store => store.value)
   const prevValue = useJsonViewerStore(store => store.prevValue)
@@ -174,5 +170,7 @@ export const JsonViewer = function JsonViewer<Value> (props: JsonViewerProps<Val
   )
 }
 
+export * from './components/DataTypes'
 export * from './theme/base16'
 export * from './type'
+export { applyValue, createDataType, isCycleReference } from './utils'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -173,4 +173,4 @@ export const JsonViewer = function JsonViewer<Value> (props: JsonViewerProps<Val
 export * from './components/DataTypes'
 export * from './theme/base16'
 export * from './type'
-export { applyValue, createDataType, isCycleReference } from './utils'
+export { applyValue, createDataType, defineDataType, isCycleReference } from './utils'

--- a/src/stores/typeRegistry.tsx
+++ b/src/stores/typeRegistry.tsx
@@ -51,7 +51,10 @@ export const useTypeRegistryStore = <U extends unknown>(selector: (state: TypeRe
 }
 
 function matchTypeComponents<Value> (
-  value: Value, path: Path, registry: TypeRegistryState['registry']): DataType<Value> {
+  value: Value,
+  path: Path,
+  registry: TypeRegistryState['registry']
+): DataType<Value> {
   let potential: DataType<Value> | undefined
   for (const T of registry) {
     if (T.is(value, path)) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -50,8 +50,18 @@ export type DataType<ValueType = unknown> = {
    * Whether the value belongs to the data type
    */
   is: (value: unknown, path: Path) => boolean
+  /**
+   * transform the value to a string for editing
+   */
+  serialize?: (value: ValueType) => string
+  /**
+   * parse the string back to a value
+   * throw an error if the input is invalid
+   * and the editor will ignore the change
+   */
+  deserialize?: (value: string) => ValueType
   Component: ComponentType<DataItemProps<ValueType>>
-  Editor?: ComponentType<EditorProps<ValueType>>
+  Editor?: ComponentType<EditorProps<string>>
   PreComponent?: ComponentType<DataItemProps<ValueType>>
   PostComponent?: ComponentType<DataItemProps<ValueType>>
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react'
 
-import type { DataItemProps, EditorProps, Path } from '../type'
+import type { DataItemProps, DataType, EditorProps, Path } from '../type'
 
 // reference: https://github.com/immerjs/immer/blob/main/src/utils/common.ts
 const objectCtorString = Object.prototype.constructor.toString()
@@ -62,6 +62,9 @@ export function applyValue (input: any, path: (string | number)[], value: any) {
   return input
 }
 
+/**
+ * @deprecated use `defineDataType` instead
+ */
 // case 1: you only render with a single component
 export function createDataType<ValueType = unknown> (
   is: (value: unknown, path: Path) => boolean,
@@ -107,7 +110,6 @@ export function createDataType<ValueType = unknown> (
   PreComponent: ComponentType<DataItemProps<ValueType>>
   PostComponent: ComponentType<DataItemProps<ValueType>>
 }
-
 export function createDataType<ValueType = unknown> (
   is: (value: unknown, path: Path) => boolean,
   Component: ComponentType<DataItemProps<ValueType>>,
@@ -115,8 +117,47 @@ export function createDataType<ValueType = unknown> (
   PreComponent?: ComponentType<DataItemProps<ValueType>> | undefined,
   PostComponent?: ComponentType<DataItemProps<ValueType>> | undefined
 ): any {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('createDataType is deprecated, please use `defineDataType` instead')
+  }
   return {
     is,
+    Component,
+    Editor,
+    PreComponent,
+    PostComponent
+  }
+}
+
+export function defineDataType<ValueType = unknown> ({
+  is,
+  serialize,
+  deserialize,
+  Component,
+  Editor,
+  PreComponent,
+  PostComponent
+}: {
+  is: (value: unknown, path: Path) => boolean
+  /**
+   * transform the value to a string for editing
+   */
+  serialize?: (value: ValueType) => string
+  /**
+   * parse the string back to a value
+   * throw an error if the input is invalid
+   * and the editor will ignore the change
+   */
+  deserialize?: (value: string) => ValueType
+  Component: ComponentType<DataItemProps<ValueType>>
+  Editor?: ComponentType<EditorProps<string>>
+  PreComponent?: ComponentType<DataItemProps<ValueType>>
+  PostComponent?: ComponentType<DataItemProps<ValueType>>
+}): DataType<ValueType> {
+  return {
+    is,
+    serialize,
+    deserialize,
     Component,
     Editor,
     PreComponent,

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { expectTypeOf } from 'expect-type'
 import { describe, expect, it } from 'vitest'
 
-import { createDataType, JsonViewer } from '../src'
+import { defineDataType, JsonViewer } from '../src'
 
 function aPlusB (a: number, b: number) {
   return a + b
@@ -258,13 +258,13 @@ describe('render <JsonViewer/> with props', () => {
               return null
             }
           },
-          createDataType<string>(
-            (value) => typeof value === 'string',
-            (props) => {
+          defineDataType<string>({
+            is: (value) => typeof value === 'string',
+            Component: (props) => {
               expectTypeOf(props.value).toMatchTypeOf<string>()
               return null
             }
-          )
+          })
         ]}
       />
     )


### PR DESCRIPTION
1. Expose built-in types like string, number, function...etc. This allows users to customize the behavior of existing components, or use part of them to combine a new data type. closes #136 \
\
For example, you can add a `PostComponent` after a link.\
![image](https://user-images.githubusercontent.com/9910706/228331868-d529de5b-346f-4a09-944f-239dd2a329cf.png)\

2. \*\***BREAKING CHANGES**\*\* Add `serialize` and `deserialize` options for editing. You will need to provide `serialize`, `deserialize` and `Editor` to enable to editing feature. closes #284 

3. Base on breaking changes from 2, we will provide a new API `defineDataType` for declaring the datatype. And the original `createDataType` will be dropped.


