### PR TITLE
ci: use `JS-DevTools/npm-publish@v2`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
+          release-type: node
           command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
   publish-json-viewer:
@@ -49,8 +50,9 @@ jobs:
         run: npm pkg delete scripts
       - name: Delete Workspaces
         run: npm pkg delete workspaces
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v2
         name: Publish to npm
         with:
           access: 'public'
           token: ${{ secrets.NPM_TOKEN }}
+          ignore-scripts: false

--- a/src/hooks/useThemeDetector.ts
+++ b/src/hooks/useThemeDetector.ts
@@ -5,9 +5,7 @@ export function useThemeDetector () {
   const [isDark, setIsDark] = useState<boolean>(false)
 
   useEffect(() => {
-    const listener = (e: MediaQueryListEvent) => {
-      setIsDark(e.matches)
-    }
+    const listener = (e: MediaQueryListEvent) => setIsDark(e.matches)
     setIsDark(window.matchMedia(query).matches)
     const queryMedia = window.matchMedia(query)
     queryMedia.addEventListener('change', listener)


### PR DESCRIPTION
CI started to fail on releasing... Let's try to upgrade the release action to V2.