### PR TITLE
fix: super long string can be partially selected without collapsing

### DIFF
--- a/src/components/DataTypes/String.tsx
+++ b/src/components/DataTypes/String.tsx
@@ -25,6 +25,10 @@ export const stringType = defineEasyType<string>({
           cursor: hasRest ? 'pointer' : 'inherit'
         }}
         onClick={() => {
+          if (window.getSelection()?.type === 'Range') {
+            return
+          }
+
           if (hasRest) {
             setShowRest(value => !value)
           }


### PR DESCRIPTION
Currently, super long string cannot be partially selected without collapsing due to "setShowRest" triggering on click