### PR TITLE
fix: remove `browser` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
   ],
   "types": "dist/index.d.ts",
   "jsdelivr": "dist/browser.js",
-  "browser": {
-    "vanilla": "dist/browser.js"
-  },
+  "unpkg": "dist/browser.js",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "exports": {


### PR DESCRIPTION
- fix https://github.com/magic-akari/seamless-scroll-polyfill/issues/147

#442