### PR TITLE
fix: missing/incorrect key when rendering self referential objects

### DIFF
--- a/docs/pages/how-to/built-in-types.mdx
+++ b/docs/pages/how-to/built-in-types.mdx
@@ -77,4 +77,4 @@ const booleanType = defineEasyType<boolean>({
 
 Did you notice the difference between the two examples?
 
-`defineEasyType` is a helper function that creates data types with type labels and colors. So you only need to care about how the balue should be rendered. All other details will be automatically handled.
+`defineEasyType` is a helper function that creates data types with type labels and colors. So you only need to care about how the value should be rendered. All other details will be automatically handled.

--- a/src/components/DataKeyPair.tsx
+++ b/src/components/DataKeyPair.tsx
@@ -361,7 +361,7 @@ export const DataKeyPair: FC<DataKeyPairProps> = (props) => {
         }
         <Box ref={highlightContainer} component='span'>
           {
-            (isRoot
+            (isRoot && depth === 0
               ? rootName !== false
                 ? (quotesOnKeys ? <>&quot;{rootName}&quot;</> : <>{rootName}</>)
                 : null


### PR DESCRIPTION
This PR fixes the issue when the key was either missing (when `rootName=false`) or the key was rendered as `"root"` if it wasn't set.

For example, for the given object:-

```
const value: any = {
  text: 'Hello World'
}
value.self = value;
```

Before (with  `rootName=false`)
<img width="891" alt="Screenshot 2024-02-07 at 6 29 03 PM" src="https://github.com/TexteaInc/json-viewer/assets/33908100/5052210e-8088-4231-99eb-f2aa5ad697a6">

After (with  `rootName=false`)
<img width="891" alt="Screenshot 2024-02-07 at 6 28 36 PM" src="https://github.com/TexteaInc/json-viewer/assets/33908100/b2b4e7c4-f2d4-4459-944f-950fb505696d">

Before (with default `rootName`)
<img width="891" alt="Screenshot 2024-02-07 at 6 29 27 PM" src="https://github.com/TexteaInc/json-viewer/assets/33908100/11233a46-36cf-440c-8f19-12d7c6bdd060">

After (with default `rootName`)
<img width="891" alt="Screenshot 2024-02-07 at 6 29 52 PM" src="https://github.com/TexteaInc/json-viewer/assets/33908100/1e9e7aed-4e09-4bba-b9bf-48c5ed10e2da">